### PR TITLE
ci: Auto generate and commit wasm binaries

### DIFF
--- a/.github/workflows/post-merge.yaml
+++ b/.github/workflows/post-merge.yaml
@@ -6,9 +6,33 @@ on:
       - master
 
 jobs:
+  generate:
+    name: Sync Generated Code
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Generate
+        run: make clean generate
+
+      - name: Commit & Push
+        shell: bash
+        run: |
+          # See https://github.com/actions/checkout#push-a-commit-using-the-built-in-token
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+
+          if ./build/commit-wasm-bins.sh; then
+            git push
+          else
+            echo "No generated changes to push!"
+          fi
+
   code-coverage:
     name: Update Go Test Coverage
     runs-on: ubuntu-18.04
+    needs: generate
     steps:
       - name: Check out code
         uses: actions/checkout@v2
@@ -27,6 +51,7 @@ jobs:
   deploy-edge:
     name: Push Edge Release
     runs-on: ubuntu-18.04
+    needs: generate
     steps:
       - name: Check out code
         uses: actions/checkout@v2
@@ -55,6 +80,7 @@ jobs:
   deploy-wasm-builder:
     name: Deploy WASM Builder
     runs-on: ubuntu-18.04
+    needs: generate
     steps:
       - name: Check out code
         uses: actions/checkout@v2

--- a/build/check-working-copy.sh
+++ b/build/check-working-copy.sh
@@ -1,8 +1,29 @@
 #!/usr/bin/env bash
 
-if output=$(git status --porcelain) && [ -z "$output" ]; then
+EXCEPTIONS=(
+  "internal/compiler/wasm/opa/opa.go"
+  "internal/compiler/wasm/opa/opa.wasm"
+)
+
+STATUS=$(git status --porcelain)
+
+HAS_CHANGES=0
+
+if [[ -z "${STATUS}" ]]; then
   exit 0
 else
+  for file in $(echo -E "${STATUS}" | awk '{print $2}'); do
+    if [[ "${EXCEPTIONS[@]}" =~ "${file}" ]]; then
+      echo "Ignoring changed file: ${file}"
+    else
+      HAS_CHANGES=1
+    fi
+  done
+fi
+
+if [[ "${HAS_CHANGES}" == "1" ]]; then
+  echo ""
+  echo "git status"
   git status
   exit 1
 fi

--- a/build/commit-wasm-bins.sh
+++ b/build/commit-wasm-bins.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+OPA_DIR=$(dirname "${BASH_SOURCE}")/..
+
+cd ${OPA_DIR}
+
+WASMFILES=(
+  "internal/compiler/wasm/opa/opa.go"
+  "internal/compiler/wasm/opa/opa.wasm"
+)
+
+for file in "${WASMFILES[@]}"; do
+  git add ${file}
+done
+
+if [[ -z "$(git diff --name-only --cached)" ]]; then
+  echo "No Wasm changes to commit!"
+  exit 1
+fi
+
+git commit -m "wasm: Update generated binaries"
+
+echo ""
+echo "Committed changes for files:"
+git diff-tree --no-commit-id --name-only -r HEAD
+echo ""


### PR DESCRIPTION
Rather than force PR's to include the generated wasm binaries we can
accept changes to require regenerating them. The post merge workflow
will now generate them and commit+push the new binaries.

The PR check for generated changes includes new functionality to
exclude files, the first ones being the wasm generated ones.

Signed-off-by: Patrick East <east.patrick@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
