### PR TITLE
compile: Support periods in decision paths

### DIFF
--- a/compile/compile.go
+++ b/compile/compile.go
@@ -247,10 +247,6 @@ func (c *Compiler) init() error {
 			return fmt.Errorf("entrypoint %v not valid: use <package>/<rule>", e)
 		}
 
-		if len(r) <= 2 {
-			return fmt.Errorf("entrypoint %v too short: use <package>/<rule>", e)
-		}
-
 		c.entrypointrefs = append(c.entrypointrefs, ast.NewTerm(r))
 	}
 

--- a/compile/compile_test.go
+++ b/compile/compile_test.go
@@ -44,16 +44,6 @@ func TestCompilerInitErrors(t *testing.T) {
 			want: fmt.Errorf("invalid target \"deadbeef\""),
 		},
 		{
-			note: "entrypoint parse error",
-			c:    New().WithEntrypoints("foo%bar"),
-			want: fmt.Errorf("entrypoint foo%%bar not valid: use <package>/<rule>"),
-		},
-		{
-			note: "entrypoint too short error",
-			c:    New().WithEntrypoints("foo"),
-			want: fmt.Errorf("entrypoint foo too short: use <package>/<rule>"),
-		},
-		{
 			note: "optimizations require entrypoint",
 			c:    New().WithOptimizationLevel(1),
 			want: errors.New("bundle optimizations require at least one entrypoint"),

--- a/internal/ref/ref.go
+++ b/internal/ref/ref.go
@@ -6,14 +6,23 @@
 package ref
 
 import (
+	"errors"
 	"strings"
 
 	"github.com/open-policy-agent/opa/ast"
+	"github.com/open-policy-agent/opa/storage"
 )
 
 // ParseDataPath returns a ref from the slash separated path s rooted at data.
 // All path segments are treated as identifier strings.
 func ParseDataPath(s string) (ast.Ref, error) {
-	s = strings.Replace(strings.Trim(s, "/"), "/", ".", -1)
-	return ast.ParseRef("data." + s)
+
+	s = "/" + strings.TrimPrefix(s, "/")
+
+	path, ok := storage.ParsePath(s)
+	if !ok {
+		return nil, errors.New("invalid path")
+	}
+
+	return path.Ref(ast.DefaultRootDocument), nil
 }


### PR DESCRIPTION
This commit updates the internal/ref package to support periods in
decision paths. This allows the opa build command to specify
entrypoints with periods in them (eg., foo/bar.baz/qux). This change
also improves the decision logger and HTTP server that rely on
internal/ref to parse mask, authorization, and default decision paths (respectively).

Signed-off-by: Torin Sandall <torinsandall@gmail.com>

<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see CONTRIBUTING.md below.

For more information on contributing to OPA see:

* [CONTRIBUTING.md](https://github.com/open-policy-agent/opa/blob/master/CONTRIBUTING.md)
  for high-level contribution guidelines.

* [DEVELOPMENT.md](https://github.com/open-policy-agent/opa/blob/master/docs/devel/DEVELOPMENT.md)
  for development workflow and environment setup.

-->
